### PR TITLE
fix: 429 TooManyProviderTokenUpdates APNs by reusing p8 digest (SDKCF-4762)

### DIFF
--- a/APNS/APNS/APNSPusher.swift
+++ b/APNS/APNS/APNSPusher.swift
@@ -236,9 +236,16 @@ private struct APNSProvider {
         Date().timeIntervalSince(timestamp) < providerTokenTTL
     }
 }
-extension APNSProvider: Equatable, Hashable {
+extension APNSProvider: Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.keyID == rhs.keyID && lhs.teamID == rhs.teamID && lhs.p8Digest == rhs.p8Digest
+    }
+}
+extension APNSProvider: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(keyID)
+        hasher.combine(teamID)
+        hasher.combine(p8Digest)
     }
 }
 extension APNSProvider: CustomStringConvertible {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.1] - TBA
+- Fix TooManyProviderTokenUpdates send to device APNS error
+
 ## [1.2.0] - 2021-11-16
 - Add "Send push to simulator" implementation (SDKCF-4031)
 - Add UI for selecting push destination - device or simulator (SDKCF-4030)


### PR DESCRIPTION
# Why?

Trying to spam myself with push (Send Push to Device + APNS Token) but I'm getting the following error from the APNs server:

>TooManyProviderTokenUpdates

The [APNs docs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns) read:

>The provider’s authentication token is being updated too often. Update the authentication token no more than once every 20 minutes.

# Solution

Fixed this issue by caching the provider token for up to 20min (persistent for the lifetime of the app) instead of regenerating a new one for each request.