### PR TITLE
chore: fix Xcode 14.3 Pods issue, update SwiftLint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,18 +2,19 @@ included:
   - APNS
   - pusher
   - PusherMainView
-
-disabled_rules:
-- identifier_name
-- function_parameter_count
-- cyclomatic_complexity
+  - FCM
 
 opt_in_rules:
 - empty_count
 - empty_string
 
-excluded:
-- Pods
+
+disabled_rules:
+- identifier_name
+- function_parameter_count
+- nesting
+- todo
+- blanket_disable_command
 
 line_length:
     warning: 150
@@ -40,7 +41,11 @@ file_length:
     ignore_comment_only_lines: true
 
 cyclomatic_complexity:
-    warning: 15
+    warning: 25
     error: 25
+
+large_tuple:
+    warning: 3
+    error: 3
 
 reporter: "xcode"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Features
 - Add JSON syntax coloring and validation (SDKCF-6431)
 
+### Fixes
+- Fixed build issues on Xcode 14.3
+
 ## [1.5.0] - 2023-03-14
 
 ### Features

--- a/Podfile
+++ b/Podfile
@@ -8,3 +8,13 @@ target 'pusher' do
     pod 'FCM', :path => 'FCM/'
     pod 'PusherMainView', :path => 'PusherMainView/', :testspecs => ['PusherMainViewTests']
 end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      if config.build_settings['MACOSX_DEPLOYMENT_TARGET'].to_f < 10.11
+        config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = '10.11'
+      end
+    end
+  end
+end

--- a/PusherMainView/PusherMainViewTests/PusherStoreSpec.swift
+++ b/PusherMainView/PusherMainViewTests/PusherStoreSpec.swift
@@ -4,9 +4,9 @@ import Quick
 import Nimble
 @testable import PusherMainView
 
-// swiftlint:disable type_body_length
-// swiftlint:disable function_body_length
+// swiftlint:disable:next type_body_length
 final class PusherStoreSpec: QuickSpec {
+    // swiftlint:disable:next function_body_length
     override func spec() {
         var router = RouterMock()
         let viewController = NSViewController()


### PR DESCRIPTION
# Description
Added Podfile that fixes linker issues with Quick and Nimble on Xcode 14.3
(Similar issue occurs for iOS project with Pods targeting iOS version <9.0)

Updated swiftlint rules to match our shared swiftlint.yml file.

## Links
n/a

# Checklist
- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors